### PR TITLE
Use head-to-head tiebreaker for league standings

### DIFF
--- a/src/app/liga/classificacao/page.jsx
+++ b/src/app/liga/classificacao/page.jsx
@@ -23,6 +23,7 @@ const Classification = () => {
   const [sortOrder, setSortOrder] = useState("desc");
   const [comparisonModalOpen, setComparisonModalOpen] = useState(false);
   const [formData, setFormData] = useState({});
+  const [leagueMatches, setLeagueMatches] = useState([]);
   const router = useRouter();
   const theme = useTheme();
 
@@ -71,13 +72,65 @@ const Classification = () => {
     fetchSeasons();
   }, []);
 
-  // Fetch form data (last 5 matches for each team)
-  const fetchFormData = async (seasonId) => {
-    const { data: matches, error } = await supabase
+  // Build form data (last 5 matches for each team) from a list of matches
+  const buildFormData = (matches) => {
+    const formByTeam = {};
+
+    matches.forEach((match) => {
+      // Process home team
+      if (!formByTeam[match.home_team_id]) {
+        formByTeam[match.home_team_id] = [];
+      }
+      if (formByTeam[match.home_team_id].length < 5) {
+        const result =
+          match.home_goals > match.away_goals
+            ? "W"
+            : match.home_goals < match.away_goals
+              ? "L"
+              : "D";
+        formByTeam[match.home_team_id].push({
+          result,
+          opponent: match.away_team.short_name,
+          score: `${match.home_goals}-${match.away_goals}`,
+          date: match.match_date,
+        });
+      }
+
+      // Process away team
+      if (!formByTeam[match.away_team_id]) {
+        formByTeam[match.away_team_id] = [];
+      }
+      if (formByTeam[match.away_team_id].length < 5) {
+        const result =
+          match.away_goals > match.home_goals
+            ? "W"
+            : match.away_goals < match.home_goals
+              ? "L"
+              : "D";
+        formByTeam[match.away_team_id].push({
+          result,
+          opponent: match.home_team.short_name,
+          score: `${match.away_goals}-${match.home_goals}`,
+          date: match.match_date,
+        });
+      }
+    });
+
+    return formByTeam;
+  };
+
+  // Fetch classification
+  const readClassification = async (seasonId) => {
+    if (!seasonId) return;
+
+    setLoading(true);
+
+    // Fetch all completed league matches once (used for form + head-to-head)
+    const { data: matches } = await supabase
       .from("matches")
       .select(
         `
-        id, match_date, home_team_id, away_team_id, 
+        id, match_date, home_team_id, away_team_id,
         home_goals, away_goals, competition_type,
         home_team:teams!matches_home_team_id_fkey (short_name),
         away_team:teams!matches_away_team_id_fkey (short_name)
@@ -89,63 +142,15 @@ const Classification = () => {
       .not("away_goals", "is", null)
       .order("match_date", { ascending: false });
 
-    if (!error && matches) {
-      const formByTeam = {};
+    const matchesList = matches || [];
+    setLeagueMatches(matchesList);
+    setFormData(buildFormData(matchesList));
 
-      matches.forEach((match) => {
-        // Process home team
-        if (!formByTeam[match.home_team_id]) {
-          formByTeam[match.home_team_id] = [];
-        }
-        if (formByTeam[match.home_team_id].length < 5) {
-          const result =
-            match.home_goals > match.away_goals
-              ? "W"
-              : match.home_goals < match.away_goals
-                ? "L"
-                : "D";
-          formByTeam[match.home_team_id].push({
-            result,
-            opponent: match.away_team.short_name,
-            score: `${match.home_goals}-${match.away_goals}`,
-            date: match.match_date,
-          });
-        }
-
-        // Process away team
-        if (!formByTeam[match.away_team_id]) {
-          formByTeam[match.away_team_id] = [];
-        }
-        if (formByTeam[match.away_team_id].length < 5) {
-          const result =
-            match.away_goals > match.home_goals
-              ? "W"
-              : match.away_goals < match.home_goals
-                ? "L"
-                : "D";
-          formByTeam[match.away_team_id].push({
-            result,
-            opponent: match.home_team.short_name,
-            score: `${match.away_goals}-${match.home_goals}`,
-            date: match.match_date,
-          });
-        }
-      });
-
-      setFormData(formByTeam);
-    }
-  };
-
-  // Fetch classification
-  const readClassification = async (seasonId) => {
-    if (!seasonId) return;
-
-    setLoading(true);
     const { data: classificationData, error } = await supabase
       .from("league_standings")
       .select(
         `
-        team_id, 
+        team_id,
         teams!league_standings_team_id_fkey (short_name, logo_url, excluded),
         matches_played, wins, draws, losses, goals_for, goals_against, points, season_year
       `
@@ -156,18 +161,86 @@ const Classification = () => {
       const sortedData = sortClassification(
         classificationData,
         sortBy,
-        sortOrder
+        sortOrder,
+        matchesList
       );
       setClassification(sortedData);
     }
 
-    // Fetch form data
-    await fetchFormData(seasonId);
-
     setLoading(false);
   };
 
-  const sortClassification = (data, field, order) => {
+  // Build head-to-head stats among a set of tied teams, using only the
+  // matches played directly between them.
+  const computeHeadToHead = (teamIds, matches) => {
+    const idSet = new Set(teamIds);
+    const stats = {};
+    teamIds.forEach((id) => {
+      stats[id] = { points: 0, goalDiff: 0, awayGoals: 0 };
+    });
+
+    matches.forEach((match) => {
+      const { home_team_id: h, away_team_id: a } = match;
+      if (
+        match.home_goals == null ||
+        match.away_goals == null ||
+        !idSet.has(h) ||
+        !idSet.has(a)
+      ) {
+        return;
+      }
+
+      const hg = match.home_goals;
+      const ag = match.away_goals;
+
+      stats[h].goalDiff += hg - ag;
+      stats[a].goalDiff += ag - hg;
+      stats[a].awayGoals += ag;
+
+      if (hg > ag) {
+        stats[h].points += 3;
+      } else if (hg < ag) {
+        stats[a].points += 3;
+      } else {
+        stats[h].points += 1;
+        stats[a].points += 1;
+      }
+    });
+
+    return stats;
+  };
+
+  // Resolve order between two teams tied on points using the head-to-head
+  // rules: 1) H2H points, 2) H2H goal difference, 3) H2H away goals.
+  // Falls back to overall goal difference → goals for → matches played.
+  const compareTiedTeams = (a, b, data, matches) => {
+    const tiedIds = data
+      .filter(
+        (t) =>
+          t.points === a.points && !t.teams.excluded && t.matches_played > 0
+      )
+      .map((t) => t.team_id);
+
+    if (tiedIds.length > 1 && matches.length) {
+      const h2h = computeHeadToHead(tiedIds, matches);
+      const sa = h2h[a.team_id];
+      const sb = h2h[b.team_id];
+      if (sa && sb) {
+        if (sa.points !== sb.points) return sb.points - sa.points;
+        if (sa.goalDiff !== sb.goalDiff) return sb.goalDiff - sa.goalDiff;
+        if (sa.awayGoals !== sb.awayGoals) return sb.awayGoals - sa.awayGoals;
+      }
+    }
+
+    // Fallback: overall goal difference → goals for → matches played
+    const gdA = a.goals_for - a.goals_against;
+    const gdB = b.goals_for - b.goals_against;
+    if (gdA !== gdB) return gdB - gdA;
+    if (a.goals_for !== b.goals_for) return b.goals_for - a.goals_for;
+    return b.matches_played - a.matches_played;
+  };
+
+  const sortClassification = (data, field, order, matches = leagueMatches) => {
     return [...data].sort((a, b) => {
       // Excluded teams always go to bottom
       if (a.teams.excluded && !b.teams.excluded) return 1;
@@ -185,14 +258,8 @@ const Classification = () => {
           if (a.points !== b.points) {
             return order === "desc" ? b.points - a.points : a.points - b.points;
           }
-          // If points are equal, use tiebreakers
-          const gdA = a.goals_for - a.goals_against;
-          const gdB = b.goals_for - b.goals_against;
-          if (gdA !== gdB) return gdB - gdA;
-          if (a.goals_for !== b.goals_for) return b.goals_for - a.goals_for;
-          if (a.matches_played !== b.matches_played)
-            return b.matches_played - a.matches_played;
-          return 0;
+          // If points are equal, use head-to-head tiebreakers
+          return compareTiedTeams(a, b, data, matches);
 
         case "goals_for":
           valueA = a.goals_for;
@@ -223,15 +290,9 @@ const Classification = () => {
           valueB = b.matches_played;
           break;
         default:
-          // Default sorting: Points → Goal Difference → Goals For → Matches Played
+          // Default sorting: Points → Head-to-head → overall fallbacks
           if (a.points !== b.points) return b.points - a.points;
-          const gdA_default = a.goals_for - a.goals_against;
-          const gdB_default = b.goals_for - b.goals_against;
-          if (gdA_default !== gdB_default) return gdB_default - gdA_default;
-          if (a.goals_for !== b.goals_for) return b.goals_for - a.goals_for;
-          if (a.matches_played !== b.matches_played)
-            return b.matches_played - a.matches_played;
-          return 0;
+          return compareTiedTeams(a, b, data, matches);
       }
 
       if (order === "desc") {
@@ -250,14 +311,17 @@ const Classification = () => {
         sortClassification(
           classification,
           field,
-          sortOrder === "desc" ? "asc" : "desc"
+          sortOrder === "desc" ? "asc" : "desc",
+          leagueMatches
         )
       );
     } else {
       // New field, default to desc
       setSortBy(field);
       setSortOrder("desc");
-      setClassification(sortClassification(classification, field, "desc"));
+      setClassification(
+        sortClassification(classification, field, "desc", leagueMatches)
+      );
     }
   };
 


### PR DESCRIPTION
## What

When league teams are tied on points, the standings now apply the head-to-head (confronto direto) tiebreaker instead of overall goal difference.

## Tiebreaker order (for teams level on points)

1. **Most H2H points** — points won in matches played directly between the tied teams
2. **H2H goal difference** — goal difference in those direct matchups
3. **H2H away goals** — most away goals scored in those head-to-head matches
4. Fallback: overall goal difference → goals for → matches played

## Implementation notes

- The tiebreaker logic lives entirely in the frontend (`src/app/liga/classificacao/page.jsx`); `league_standings` only stores aggregate totals, so H2H is computed from the `matches` rows.
- The league matches were already being fetched for the form guide — that fetch is now done once and reused for both the form guide and the H2H computation.
- H2H is computed as a mini-league among **all** teams sharing the same points, so the 3+-tied-teams case is handled correctly, not just pairwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)